### PR TITLE
refactor(signals, with-collection-service): Update key names

### DIFF
--- a/packages/rxdb/signals/src/with-collection-service.ts
+++ b/packages/rxdb/signals/src/with-collection-service.ts
@@ -227,12 +227,12 @@ export function withCollectionService<
     // state: { callState: CallState } & NamedEntityState<E, Collection>,
     // state: NamedEntityState<E, Collection>,
 
-    signals: NamedEntitySignals<E, CName>;
+    computed: NamedEntitySignals<E, CName>;
     methods: Record<string, never>;
   },
   {
     state: NamedCollectionServiceState<E, F, CName>;
-    signals: NamedCollectionServiceSignals<E, CName>;
+    computed: NamedCollectionServiceSignals<E, CName>;
     methods: NamedCollectionServiceMethods<E, F, CName>;
   }
 >;
@@ -244,7 +244,7 @@ export function withCollectionService<E extends Entity, F extends Filter>(option
   SignalStoreFeatureResult,
   {
     state: CollectionServiceState<E, F>;
-    signals: CollectionServiceSignals<E>;
+    computed: CollectionServiceSignals<E>;
     methods: CollectionServiceMethods<E, F>;
   }
 >;


### PR DESCRIPTION
replace "signals" key with "computed" key to be type compatible wit the latest ngrx release

<table>
<tbody>
 <tr>
<td>

```ts

SignalStoreFeature<{
    state: ... ,
    signals: ... ,    // old name
   methods: ... 
}>

```

</td>
<td>

```ts

SignalStoreFeature<{
    state: ... ,
    computed: ... ,    // <--!!! new name
   methods: ... 
}>

```
</td>
</tr>
</tbody></table>


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/voznik/ngx-odm/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

with the latest release of ngrx the withCollectionService method is type incompatible with the the ngrx "signalStore".


Issue Number: N/A

## What is the new behavior?

the "withCollectionService" becomes compatible with the "signalStore" method

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
