### PR TITLE
refactor(examples): remove zoneless workarounds for Angular 21

### DIFF
--- a/examples/standalone/src/app/app.component.ts
+++ b/examples/standalone/src/app/app.component.ts
@@ -1,7 +1,5 @@
-import { Component, inject, ChangeDetectorRef } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { NavigationEnd, Router, RouterModule } from '@angular/router';
-import { filter } from 'rxjs';
+import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   imports: [RouterModule],
@@ -10,20 +8,4 @@ import { filter } from 'rxjs';
     <router-outlet></router-outlet>
   `,
 })
-export class AppComponent {
-  private router = inject(Router);
-  private cdr = inject(ChangeDetectorRef);
-
-  constructor() {
-    this.zonelessCD();
-  }
-
-  private zonelessCD(): void {
-    this.router.events
-      .pipe(
-        filter(event => event instanceof NavigationEnd),
-        takeUntilDestroyed()
-      )
-      .subscribe(() => this.cdr.detectChanges());
-  }
-}
+export class AppComponent {}

--- a/examples/standalone/src/app/app.config.ts
+++ b/examples/standalone/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
-import { ApplicationConfig, NgZone, ɵNoopNgZone } from '@angular/core';
+import { ApplicationConfig } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter, withRouterConfig } from '@angular/router';
 import { provideRxDatabase } from '@ngx-odm/rxdb';
@@ -16,7 +16,7 @@ if (!environment.production) {
 
 export const appConfig: ApplicationConfig = {
   providers: [
-    { provide: NgZone, useClass: ɵNoopNgZone },
+    // { provide: NgZone, useClass: ɵNoopNgZone },
     provideRouter(appRoutes, withRouterConfig({ onSameUrlNavigation: 'reload' })),
     provideAnimationsAsync(),
     provideHttpClient(),

--- a/examples/standalone/src/app/todos/todos.component.html
+++ b/examples/standalone/src/app/todos/todos.component.html
@@ -21,7 +21,7 @@
     />
     <label for="toggle-all" title="Mark all as complete">Mark all as complete</label>
     <ul [@listAnimation]="todoStore.filter()" class="todo-list">
-      @for (todo of todos; track trackByFn($index, todo)) {
+      @for (todo of todoStore.filtered(); track trackByFn($index, todo)) {
         <li [class.completed]="todo.completed">
           <div class="view">
             <input

--- a/examples/standalone/src/app/todos/todos.component.ts
+++ b/examples/standalone/src/app/todos/todos.component.ts
@@ -1,11 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  Component,
-  effect,
-  inject,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { provideRxCollection } from '@ngx-odm/rxdb';
 import { Todo, TODOS_COLLECTION_CONFIG, todosListAnimation } from '@shared';
@@ -24,10 +18,8 @@ import { TodoStore } from './todos.store';
   ],
 })
 export class TodosComponent {
-  private cdr = inject(ChangeDetectorRef);
   private titleService = inject(Title);
   readonly todoStore = inject(TodoStore);
-  todos: Todo[] = []; // Copy todos from store inside effect to properly trigger zoneless change detection
 
   trackByFn = (index: number, item: Todo) => {
     return item.id + item.last_modified;
@@ -35,13 +27,8 @@ export class TodosComponent {
 
   constructor() {
     effect(() => {
-      const { filtered, title } = this.todoStore;
-      this.todos = filtered(); // Copy todos from store inside effect to properly trigger zoneless change detection
-      const titleString = title();
+      const titleString = this.todoStore.title();
       this.titleService.setTitle(titleString);
-
-      // INFO: Angular 17 doesn't provide way to detect changes with `signals` ONLY and no zone
-      this.cdr.detectChanges();
     });
   }
 }

--- a/examples/standalone/src/app/todos/todos.store.ts
+++ b/examples/standalone/src/app/todos/todos.store.ts
@@ -12,9 +12,7 @@ import { withEntities } from '@ngrx/signals/entities';
 import { withCollectionService } from '@ngx-odm/rxdb/signals';
 import { NgxRxdbUtils } from '@ngx-odm/rxdb/utils';
 import { Todo, TodosFilter } from '@shared';
-import { derivedFrom } from 'ngxtension/derived-from';
 import { firstPropertyValueOfObject } from 'rxdb/plugins/utils';
-import { map, pipe } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 
 const { isEmpty, isValidNumber } = NgxRxdbUtils;
@@ -58,17 +56,14 @@ export const TodoStore = signalStore(
 
     const remaining = computed(() => countFiltered());
 
-    const title = derivedFrom(
-      [countAll, remaining],
-      pipe(
-        map(([all, rem]) => {
-          if (!isValidNumber(all) || !isValidNumber(rem)) {
-            return '';
-          }
-          return `(${all - rem}/${all}) Todos done`;
-        })
-      )
-    );
+    const title = computed(() => {
+      const all = countAll();
+      const rem = remaining();
+      if (!isValidNumber(all) || !isValidNumber(rem)) {
+        return '';
+      }
+      return `(${all - rem}/${all}) Todos done`;
+    });
 
     const sortDir = computed(() => {
       const curQuery = query();

--- a/examples/standalone/src/main.ts
+++ b/examples/standalone/src/main.ts
@@ -1,4 +1,4 @@
-import { provideZoneChangeDetection } from '@angular/core';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import 'process/browser';
 import { AppComponent } from './app/app.component';
@@ -6,5 +6,5 @@ import { appConfig } from './app/app.config';
 
 bootstrapApplication(AppComponent, {
   ...appConfig,
-  providers: [provideZoneChangeDetection(), ...appConfig.providers],
+  providers: [provideZonelessChangeDetection(), ...appConfig.providers],
 }).catch(err => console.error(err));


### PR DESCRIPTION
## Summary
- Use `provideZonelessChangeDetection()` instead of custom zone handling
- Remove manual CD triggers from AppComponent and TodosComponent
- Simplify title signal to use `computed` instead of `derivedFrom`
- Remove unused rxjs and ngxtension imports